### PR TITLE
Introduced the new API for atoms

### DIFF
--- a/eo-python-runtime/src/eo2py/atoms.py
+++ b/eo-python-runtime/src/eo2py/atoms.py
@@ -239,16 +239,18 @@ class Array(Atom):
     def data(self) -> List:
         return [elem.dataize().data() for elem in self.elements]
 
-    def __getitem__(self, item: Number):
+    def __getitem__(self, item: Object):
         if isinstance(item, Number):
             assert isinstance(item.value, int)
-            return self.elements[item.data()]
+            index = item.dataize().data()
+            assert isinstance(index, int)
+            return self.elements[index]
         else:
             raise AttributeError(f"{item} is not an instance of Number!")
 
 
 class ArrayGet(Object):
-    def __init__(self, arr: Array, i: Number):
+    def __init__(self, arr: Array, i: Object):
         self.arr = arr
         self.i = i
 

--- a/eo-python-runtime/tests/atoms/simple_object.py
+++ b/eo-python-runtime/tests/atoms/simple_object.py
@@ -1,24 +1,25 @@
 from eo2py.atoms import *
+import pytest
 
 """
 [name] > person
 """
 
 
-class EOperson(EObase):
-    def __init__(self, name: EObase, ):
-        self.name = name
-        self.__PHI__ = EOerror(
-            # "The object cannot be dataized because it doesn't contain @ attribute"
-        )
-        self.__PARENT__ = EOerror(
-            # "This is a toplevel object, it has no parents"
-        )
+class EOperson(Object):
+    def __init__(self, name: Object, ):
+        # Special attributes
+        self.__PHI__ = DataizationError()
+        self.__PARENT__ = DataizationError()
         self.__THIS__ = self
 
-    def generate_attributes(self):
-        pass
+        # Free attributes
+        self.name = name
 
-    def dataize(self):
-        self.generate_attributes()
-        self.__PHI__.dataize()
+    def dataize(self) -> object:
+        return self.__PHI__.dataize()
+
+
+def test_person():
+    with pytest.raises(NotImplementedError) as e:
+        assert EOperson(String("Kate")).dataize()

--- a/eo-python-runtime/tests/atoms/test_atoms.py
+++ b/eo-python-runtime/tests/atoms/test_atoms.py
@@ -5,56 +5,71 @@ import math
 
 def test_base():
     with pytest.raises(NotImplementedError) as e:
-        EObase().dataize()
+        Object().dataize()
 
 
 def test_error():
     with pytest.raises(NotImplementedError) as e:
-        EOerror().dataize()
+        DataizationError().dataize()
 
 
 @pytest.mark.parametrize("a", list(range(1, 10)))
 @pytest.mark.parametrize("b", list(range(1, 10)))
 def test_number(a, b):
-    assert EOnumber(a) == EOnumber(EOnumber(a).data())
-    assert EOnumber(a) - EOnumber(b) == EOnumber(a).sub(EOnumber(b)).dataize() == EOnumber(a - b)
-    assert EOnumber(a) + EOnumber(b) == EOnumber(a).add(EOnumber(b)).dataize() == EOnumber(a + b)
-    assert EOnumber(a) * EOnumber(b) == EOnumber(a).mul(EOnumber(b)).dataize() == EOnumber(a * b)
-    assert EOnumber(a) ** EOnumber(b) == EOnumber(a).pow(EOnumber(b)).dataize() == EOnumber(math.pow(a, b))
-    assert (EOnumber(a) < EOnumber(b)) == EOnumber(a).less(EOnumber(b)).dataize() == \
-           EObool("true" if a < b else "false")
-    assert (EOnumber(a) <= EOnumber(b)) == EOnumber(a).leq(EOnumber(b)).dataize() == \
-           EObool("true" if a <= b else "false")
+    assert Number(a) == Number(Number(a).data())
+    assert Number(a) - Number(b) == Number(a).Sub(Number(b)).dataize() == Number(a - b)
+    assert Number(a) + Number(b) == Number(a).Add(Number(b)).dataize() == Number(a + b)
+    assert Number(a) * Number(b) == Number(a).Mul(Number(b)).dataize() == Number(a * b)
+    assert (
+        Number(a) ** Number(b)
+        == Number(a).Pow(Number(b)).dataize()
+        == Number(math.pow(a, b))
+    )
+    assert (
+        (Number(a) < Number(b))
+        == Number(a).Less(Number(b)).dataize()
+        == Boolean("true" if a < b else "false")
+    )
+    assert (
+        (Number(a) <= Number(b))
+        == Number(a).Leq(Number(b)).dataize()
+        == Boolean("true" if a <= b else "false")
+    )
 
 
 def test_string():
     value = "String"
-    assert str(EOstring(value)) == str(EOstring(value).dataize()) == EOstring(value).data() == value
+    assert (
+        str(String(value))
+        == str(String(value).dataize())
+        == String(value).data()
+        == value
+    )
 
 
 def test_array():
-    arr = EOarray(EOnumber(1), EOnumber(2), EOnumber(3), EOnumber(4), EOnumber(5))
+    arr = Array(Number(1), Number(2), Number(3), Number(4), Number(5))
     assert arr.dataize() == arr
     assert arr.dataize().data() == arr.data() == [1, 2, 3, 4, 5]
-    assert arr[EOnumber(2)] == EOnumber(3)
+    assert arr[Number(2)] == Number(3)
     with pytest.raises(AttributeError) as e:
-        assert arr[2] == EOnumber(3)
+        assert arr[2] == Number(3)
 
 
 def test_bool():
-    true = EObool("true")
-    false = EObool("false")
-    assert true == EObool("TRUE") == EObool("True") == EObool(" \n True\n")
-    assert false == EObool("FALSE") == EObool("False") == EObool("\t\rFalse")
+    true = Boolean("true")
+    false = Boolean("false")
+    assert true == Boolean("TRUE") == Boolean("True") == Boolean(" \n True\n")
+    assert false == Boolean("FALSE") == Boolean("False") == Boolean("\t\rFalse")
     with pytest.raises(AssertionError) as e:
-        false = EObool("string")
+        false = Boolean("string")
     assert true and not false
-    assert str(true) == "EObool(True)"
-    assert str(false) == "EObool(False)"
+    assert str(true) == "Boolean(True)"
+    assert str(false) == "Boolean(False)"
 
 
 def test_stdout(capsys):
-    stdout = EOstdout(EOstring("Test"))
+    stdout = Stdout(String("Test"))
     assert stdout.data() is None
     stdout.dataize()
     assert capsys.readouterr().out == "Test\n"
@@ -67,18 +82,24 @@ def test_lazy_property():
             return 12
 
     obj = A()
-    assert hasattr(obj, 'a')
+    assert hasattr(obj, "a")
     assert obj.a == 12
 
 
-if __name__ == "__main__":
-    assert EOattr(EOnumber(2), 'add', EOnumber(2)).dataize() == EOnumber(4)
-    assert EOattr(EOnumber(2), 'add', EOattr(EOnumber(2), 'add', EOnumber(2))).dataize() == EOnumber(6)
-    assert EOattr(EOattr(EOnumber(2), 'add', EOnumber(2)), 'add', EOnumber(2)).dataize() == EOnumber(6)
-    dx = EOnumber(2)
-    dy = EOnumber(2)
-    dx_squared = EOattr(dx, 'pow', EOnumber(2))
-    dy_squared = EOattr(dy, 'pow', EOnumber(2))
-    dx_squared_plus_dy_squared = EOattr(dx_squared, 'add', dy_squared)
-    sqrt_dx_squared_plus_dy_squared = EOattr(dx_squared_plus_dy_squared, 'pow', EOnumber(0.5))
-    assert sqrt_dx_squared_plus_dy_squared.dataize() == EOnumber(8 ** 0.5)
+def attribute_test():
+    assert Attribute(Number(2), "add").applied_to(Number(2)).dataize() == Number(4)
+    assert Attribute(Number(2), "add").applied_to(
+        Attribute(Number(2), "add").applied_to(Number(2))
+    ).dataize() == Number(6)
+    assert Attribute(
+        Attribute(Number(2), "add").applied_to(Number(2)), "add"
+    ).applied_to(Number(2)).dataize() == Number(6)
+    dx = Number(2)
+    dy = Number(2)
+    dx_squared = Attribute(dx, "pow").applied_to(Number(2))
+    dy_squared = Attribute(dy, "pow").applied_to(Number(2))
+    dx_squared_plus_dy_squared = Attribute(dx_squared, "add").applied_to(dy_squared)
+    sqrt_dx_squared_plus_dy_squared = Attribute(
+        dx_squared_plus_dy_squared, "pow"
+    ).applied_to(Number(0.5))
+    assert sqrt_dx_squared_plus_dy_squared.dataize() == Number(8 ** 0.5)

--- a/eo-python-runtime/tests/atoms/test_atoms.py
+++ b/eo-python-runtime/tests/atoms/test_atoms.py
@@ -13,6 +13,13 @@ def test_error():
         DataizationError().dataize()
 
 
+def test_atom():
+    with pytest.raises(NotImplementedError):
+        Atom().dataize()
+    with pytest.raises(NotImplementedError):
+        Atom().data()
+
+
 @pytest.mark.parametrize("a", list(range(1, 10)))
 @pytest.mark.parametrize("b", list(range(1, 10)))
 def test_number(a, b):
@@ -21,29 +28,29 @@ def test_number(a, b):
     assert Number(a) + Number(b) == Number(a).Add(Number(b)).dataize() == Number(a + b)
     assert Number(a) * Number(b) == Number(a).Mul(Number(b)).dataize() == Number(a * b)
     assert (
-        Number(a) ** Number(b)
-        == Number(a).Pow(Number(b)).dataize()
-        == Number(math.pow(a, b))
+            Number(a) ** Number(b)
+            == Number(a).Pow(Number(b)).dataize()
+            == Number(math.pow(a, b))
     )
     assert (
-        (Number(a) < Number(b))
-        == Number(a).Less(Number(b)).dataize()
-        == Boolean("true" if a < b else "false")
+            (Number(a) < Number(b))
+            == Number(a).Less(Number(b)).dataize()
+            == Boolean("true" if a < b else "false")
     )
     assert (
-        (Number(a) <= Number(b))
-        == Number(a).Leq(Number(b)).dataize()
-        == Boolean("true" if a <= b else "false")
+            (Number(a) <= Number(b))
+            == Number(a).Leq(Number(b)).dataize()
+            == Boolean("true" if a <= b else "false")
     )
 
 
 def test_string():
     value = "String"
     assert (
-        str(String(value))
-        == str(String(value).dataize())
-        == String(value).data()
-        == value
+            str(String(value))
+            == str(String(value).dataize())
+            == String(value).data()
+            == value
     )
 
 
@@ -63,6 +70,8 @@ def test_bool():
     assert false == Boolean("FALSE") == Boolean("False") == Boolean("\t\rFalse")
     with pytest.raises(AssertionError) as e:
         false = Boolean("string")
+    with pytest.raises(AttributeError) as e:
+        false = Boolean(123)
     assert true and not false
     assert str(true) == "Boolean(True)"
     assert str(false) == "Boolean(False)"

--- a/eo-python-runtime/tests/example_programs/test_factorial.py
+++ b/eo-python-runtime/tests/example_programs/test_factorial.py
@@ -26,7 +26,7 @@ from eo2py.atoms import *
 """
 
 
-class factorial(EObase):
+class EOfactorial(Object):
     def __init__(self, n):
         self.n = n
         self.__PARENT__ = self
@@ -34,44 +34,36 @@ class factorial(EObase):
 
     @property
     def __PHI__(self):
-        return EOattr(
-            EOattr(self.n, 'less', EOnumber(2)),
-            'If',
-            EOnumber(1),
-            EOattr(self.n,
-                   'mul',
-                   factorial(
-                       EOattr(self.n, 'sub', EOnumber(1))
-                   )
-                   )
+        return Attribute(
+            Attribute(self.n, "Less").applied_to(Number(2)),
+            "If",
+        ).applied_to(
+            Number(1),
+            Attribute(self.n, "Mul").applied_to(
+                EOfactorial(Attribute(self.n, "Sub").applied_to(Number(1)))
+            ),
         )
 
     def dataize(self) -> object:
         return self.__PHI__.dataize()
 
 
-class appFactorial(EObase):
+class EOappFactorial(Object):
     def __init__(self, *args):
-        self.args = EOarray(*args)
+        self.args = Array(*args)
 
     @property
     def n(self):
-        return EOattr(self.args, 'get', EOnumber(0))
+        return Attribute(self.args, "get").applied_to(Number(0))
 
     @property
     def __PHI__(self):
-        return EOstdout(
-            EOsprintf(
-                EOstring("%d! = %d"),
-                self.n,
-                factorial(self.n)
-            )
-        )
+        return Stdout(FormattedString(String("%d! = %d"), self.n, EOfactorial(self.n)))
 
     def dataize(self) -> object:
         return self.__PHI__.dataize()
 
 
 def test_factorial():
-    app = factorial(EOnumber(5))
-    assert app.dataize() == EOnumber(120)
+    app = EOfactorial(Number(5))
+    assert app.dataize() == Number(120)

--- a/eo-python-runtime/tests/example_programs/test_fibonacci.py
+++ b/eo-python-runtime/tests/example_programs/test_fibonacci.py
@@ -14,24 +14,24 @@ from eo2py.atoms import *
 
 
 # TODO: figure out type resolution
-class fibonacci(EObase):
-    def __init__(self, n: EObase):
+class EOfibonacci(Object):
+    def __init__(self, n: Object):
         # super().__init__(0)
         self.n = n
-        self.__PARENT__ = EOerror()
+        self.__PARENT__ = DataizationError()
         self.__THIS__ = self
 
     @property
     def __PHI__(self):
-        return EOattr(
-            EOattr(self.n, 'less', EOnumber(2)),
-            'If',
+        return Attribute(
+            Attribute(self.n, "Less").applied_to(Number(2)),
+            "If",
+        ).applied_to(
             self.n,
-            EOattr(
-                fibonacci(EOattr(self.n, 'sub', EOnumber(1))),
-                'add',
-                fibonacci(EOattr(self.n, 'sub', EOnumber(2)))
-            )
+            Attribute(
+                EOfibonacci(Attribute(self.n, "Sub").applied_to(Number(1))),
+                "Add",
+            ).applied_to(EOfibonacci(Attribute(self.n, "Sub").applied_to(Number(2)))),
         )
 
     def dataize(self):
@@ -39,5 +39,5 @@ class fibonacci(EObase):
 
 
 def test_fibonacci():
-    res = fibonacci(EOnumber(10))
-    assert res.dataize() == EOnumber(55)
+    res = EOfibonacci(Number(10))
+    assert res.dataize() == Number(55)

--- a/eo-python-runtime/tests/example_programs/test_simple_array.py
+++ b/eo-python-runtime/tests/example_programs/test_simple_array.py
@@ -14,20 +14,15 @@ from eo2py.atoms import *
 """
 
 
-class appArray(EObase):
+class EOappArray(Object):
     def __init__(self, *args):
         self.args = args
 
     @property
     def __PHI__(self):
-        return EOstdout(
-            EOsprintf(
-                EOstring("%d"),
-                EOattr(
-                    EOarray(*self.args),
-                    'get',
-                    EOnumber(3)
-                )
+        return Stdout(
+            FormattedString(
+                String("%d"), Attribute(Array(*self.args), "Get").applied_to(Number(3))
             )
         )
 
@@ -36,11 +31,11 @@ class appArray(EObase):
 
 
 def test_simple_array():
-    app = appArray(
-        EOnumber(1),
-        EOnumber(2),
-        EOnumber(3),
-        EOnumber(4),
-        EOnumber(5),
+    app = EOappArray(
+        Number(1),
+        Number(2),
+        Number(3),
+        Number(4),
+        Number(5),
     )
     assert app.dataize()

--- a/eo-python-runtime/tests/example_programs/test_vector.py
+++ b/eo-python-runtime/tests/example_programs/test_vector.py
@@ -39,12 +39,11 @@ from eo2py.atoms import *
 """
 
 
-class vector(EObase):
-
+class EOvector(Object):
     def __init__(self, dx, dy):
         # Special attributes
-        self.__PHI__ = EOerror()
-        self.__PARENT__ = EOerror()
+        self.__PHI__ = DataizationError()
+        self.__PARENT__ = DataizationError()
         self.__SELF__ = self
 
         # Free attributes
@@ -54,15 +53,13 @@ class vector(EObase):
     @property
     def length(self):
         # Bound attributes
-        return EOattr(
-            EOattr(
-                EOattr(self.dx, 'pow', EOnumber(2)),
-                'add',
-                EOattr(self.dy, 'pow', EOnumber(2))
-            ),
-            'pow',
-            EOnumber(0.5)
-        )
+        return Attribute(
+            Attribute(
+                Attribute(self.dx, "Pow").applied_to(Number(2)),
+                "Add",
+            ).applied_to(Attribute(self.dy, "Pow").applied_to(Number(2))),
+            "Pow",
+        ).applied_to(Number(0.5))
 
     def dataize(self) -> object:
         return self.__PHI__.dataize()
@@ -72,8 +69,7 @@ class vector(EObase):
 
 
 # Inner abstract object
-class point_distance(EObase):
-
+class EOpoint_distance(Object):
     def __init__(self, __PARENT__, to):
         # Special attributes
         super().__init__()
@@ -86,12 +82,16 @@ class point_distance(EObase):
     @property
     def __PHI__(self):
         # Bound attributes
-        return EOattr(
-            vector(
-                EOattr(EOattr(self.to, 'x'), 'sub', EOattr(self.__PARENT__, 'x')),
-                EOattr(EOattr(self.to, 'x'), 'sub', EOattr(self.__PARENT__, 'x'))
+        return Attribute(
+            EOvector(
+                Attribute(Attribute(self.to, "x"), "Sub").applied_to(
+                    Attribute(self.__PARENT__, "x")
+                ),
+                Attribute(Attribute(self.to, "x"), "Sub").applied_to(
+                    Attribute(self.__PARENT__, "x")
+                ),
             ),
-            'length'
+            "length",
         )
 
     def dataize(self) -> object:
@@ -99,12 +99,12 @@ class point_distance(EObase):
 
 
 # Abstract object is assigned just as attribute
-class point(EObase):
+class EOpoint(Object):
     def __init__(self, x, y):
         # Special attributes
         super().__init__()
-        self.__PHI__ = EOerror()
-        self.__PARENT__ = EOerror()
+        self.__PHI__ = DataizationError()
+        self.__PARENT__ = DataizationError()
         self.__SELF__ = self
 
         # Free attributes
@@ -114,7 +114,7 @@ class point(EObase):
     @property
     def distance(self):
         # Bound attributes
-        return partial(point_distance, self)
+        return partial(EOpoint_distance, self)
 
     def dataize(self) -> object:
         return self.__PHI__.dataize()
@@ -123,34 +123,25 @@ class point(EObase):
         return f"point(x={self.x}, y={self.y})"
 
 
-class circle_is_inside(EObase):
+class EOcircle_is_inside(Object):
     def __init__(self, __PARENT__, p):
         self.p = p
         self.__PARENT__ = __PARENT__
 
     @property
     def __PHI__(self):
-        return EOattr(
-            EOattr(
-                self.__PARENT__,
-                'distance',
-                self.p
-            ),
-            'leq',
-            EOattr(
-                self.__PARENT__,
-                'radius'
-            )
-        )
+        return Attribute(
+            Attribute(self.__PARENT__, "distance").applied_to(self.p), "Leq"
+        ).applied_to(Attribute(self.__PARENT__, "radius"))
 
-    def dataize(self) -> EObase:
+    def dataize(self) -> Object:
         return self.__PHI__.dataize()
 
     def __str__(self):
         return f"{self.__PARENT__}.is_inside(p={self.p})"
 
 
-class circle(EObase):
+class EOcircle(Object):
     def __init__(self, center, radius):
         self.center = center
         self.radius = radius
@@ -161,20 +152,20 @@ class circle(EObase):
 
     @property
     def is_inside(self):
-        return partial(circle_is_inside, self)
+        return partial(EOcircle_is_inside, self)
 
-    def dataize(self) -> EObase:
+    def dataize(self) -> Object:
         return self.__PHI__.dataize()
 
     def __str__(self):
         return f"circle(center={self.center}, radius={self.radius})"
 
 
-class app(EObase):
+class EOapp(Object):
     def __init__(self, *args, **kwargs):
         # Special attributes
         super().__init__()
-        self.__PARENT__ = EOerror()
+        self.__PARENT__ = DataizationError()
         self.__SELF__ = self
 
         # Free attributes
@@ -183,17 +174,12 @@ class app(EObase):
     @property
     def __PHI__(self):
         # Bound attributes
-        return EOstdout(
-            EOsprintf(
-                "%s\n",
-                EOattr(
-                    circle(
-                        point(EOnumber(1), EOnumber(1)),
-                        EOnumber(2)
-                    ),
-                    'is_inside',
-                    point(EOnumber(22), EOnumber(1))
-                )
+        return Stdout(
+            FormattedString(
+                String("%s\n"),
+                Attribute(
+                    EOcircle(EOpoint(Number(1), Number(1)), Number(2)), "is_inside"
+                ).applied_to(EOpoint(Number(22), Number(1))),
             )
         )
 
@@ -202,4 +188,4 @@ class app(EObase):
 
 
 def test_vector():
-    assert app().dataize()
+    assert EOapp().dataize()

--- a/eo-python-runtime/tests/example_programs/test_vector.py
+++ b/eo-python-runtime/tests/example_programs/test_vector.py
@@ -87,8 +87,8 @@ class EOpoint_distance(Object):
                 Attribute(Attribute(self.to, "x"), "Sub").applied_to(
                     Attribute(self.__PARENT__, "x")
                 ),
-                Attribute(Attribute(self.to, "x"), "Sub").applied_to(
-                    Attribute(self.__PARENT__, "x")
+                Attribute(Attribute(self.to, "y"), "Sub").applied_to(
+                    Attribute(self.__PARENT__, "y")
                 ),
             ),
             "length",

--- a/eo2py-maven-plugin/src/main/resources/org.eolang.maven/pre/data.xsl
+++ b/eo2py-maven-plugin/src/main/resources/org.eolang.maven/pre/data.xsl
@@ -32,22 +32,22 @@ SOFTWARE.
         <xsl:attribute name="python-type">
           <xsl:choose>
             <xsl:when test="@data='string'">
-              <xsl:text>EOString</xsl:text>
+              <xsl:text>String</xsl:text>
             </xsl:when>
             <xsl:when test="@data='regex'">
-              <xsl:text>EORegex</xsl:text>
+              <xsl:text>Regex</xsl:text>
             </xsl:when>
             <xsl:when test="@data='char'">
-              <xsl:text>EOString</xsl:text>
+              <xsl:text>String</xsl:text>
             </xsl:when>
             <xsl:when test="@data='float'">
-              <xsl:text>EOFloat</xsl:text>
+              <xsl:text>Number</xsl:text>
             </xsl:when>
             <xsl:when test="@data='int'">
-              <xsl:text>EOInt</xsl:text>
+              <xsl:text>Number</xsl:text>
             </xsl:when>
             <xsl:when test="@data='bool'">
-              <xsl:text>EOBoolean</xsl:text>
+              <xsl:text>Boolean</xsl:text>
             </xsl:when>
             <xsl:otherwise>
               <xsl:message terminate="yes">
@@ -105,14 +105,6 @@ SOFTWARE.
             <xsl:value-of select="text()"/>
             <xsl:text>"</xsl:text>
           </xsl:when>
-<!--          <xsl:when test="@data='int'">-->
-<!--            <xsl:value-of select="text()"/>-->
-<!--            <xsl:text>L</xsl:text>-->
-<!--          </xsl:when>-->
-<!--          <xsl:when test="@data='float'">-->
-<!--            <xsl:value-of select="text()"/>-->
-<!--            <xsl:text>d</xsl:text>-->
-<!--          </xsl:when>-->
           <xsl:otherwise>
             <xsl:value-of select="text()"/>
           </xsl:otherwise>

--- a/sandbox/eo/app.eo
+++ b/sandbox/eo/app.eo
@@ -16,10 +16,19 @@
         to.x.sub (^.x)
         to.y.sub (^.y)
 
+[center radius] > circle
+  center > @
+  [p] > is-inside
+    leq. > @
+      ^.distance p
+      ^.radius
+
 [args...] > app
   stdout > @
     sprintf
-      "%f\n"
-      distance.
-        point 1.0 2.0
-        point 4.0 6.0
+      "%b\n"
+      is-inside.
+        circle
+          point 1.0 1.0
+          2.0
+        point 1.0 1.0


### PR DESCRIPTION
## Changes
### `atoms.py`
- All atoms were renamed from `EO<lowercase_word>` to <CamelCase>, e.g. `EOnumber` was renamed to `Number`, `EObool_EOif` was renamed to `BooleanIf`
- All attributes that were initialized in constructor now start from capital letter, e.g. `Number(2).Add(Number(2))`.
- Attribute now has a method `.applied_to()`, which is now responsible for setting the `args` attribute. This change is intended to draw a clear line between __attribute acquisition__ and __attribute application__, without breaking much functionality.  The previous example would look like:
```python
Attribute(Number(2), 'Add').applied_to(Number(2))
```
- LOTS of refactoring and type hints.
### Example programs
- All the above changes were applied to the existing test cases.
- Generated classes' names are now prefixed with `EO`: `EOfibonacci`, `EOfactorial`, etc. As per #12.

### `black`
- All the files were formatted with [`black`](https://github.com/psf/black).
